### PR TITLE
Add GitHub workflow to auto create PR on `content/main` push

### DIFF
--- a/.github/workflows/on-content-push-creates-pr.yml
+++ b/.github/workflows/on-content-push-creates-pr.yml
@@ -1,0 +1,28 @@
+name: Create PR on `content/main` Push
+
+on:
+  push:
+    branches:
+      - 'content/main'
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: content/main
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v7
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        title: 'Automated PR: Content/Main to Main'
+        body: 'This PR was automatically generated from content/main to main'
+        commit-message: 'Auto-commit PR changes from content/main'
+        labels: automated-pr


### PR DESCRIPTION
- Issue: https://git.chen.so/www.chen.software/i/b1a90586efd6e85d01419e4d772a3ff9215c495e
- Patch: https://git.chen.so/www.chen.software/p/c19dba2ea6544096776781e91ccd2970d0320224
- https://github.com/Chen-Software/www.chen.software/pull/8